### PR TITLE
Dev'ed on Win10 with cygwin gcc 4.9.3

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -210,7 +210,7 @@ int main(int argc, char *argv[])
     bool manualSeedMinFlag = false;
     bool manualSeedMaxFlag = false;
     bool timestampFlag = false;
-    uint32_t seed = 0;
+    uint64_t seed = 0;
     uint32_t generationDepth = 20;
     uint32_t min_bound = 0;
     uint32_t max_bound = -1;
@@ -252,7 +252,7 @@ int main(int argc, char *argv[])
             {
                 if(optarg != NULL)
                 {
-                    seed = strtoul(optarg, NULL, 10);
+                    seed = strtoll(optarg, NULL, 10);
                 }
                 generateFlag = true;
                 break;

--- a/prngs/Java.cpp
+++ b/prngs/Java.cpp
@@ -35,13 +35,13 @@ const std::string Java::getName()
 void Java::seed(int64_t value)
 {
     m_originalSeed = value;
-    m_seedValue = (value ^ 0x5DEECE66DL) & ((1L << 48) - 1);
+    m_seedValue = (value ^ 0x5DEECE66DL) & ((1LL << 48) - 1);
 }
 
 int32_t Java::next(int32_t bits)
 {
     /* Update the seed */
-    m_seedValue = (m_seedValue * 0x5DEECE66DL + 0xBL) & ((1L << 48) - 1);
+    m_seedValue = (m_seedValue * 0x5DEECE66DL + 0xBL) & ((1LL << 48) - 1);
     /* Return bits of the seed, masked out. */
     return (int32_t)(m_seedValue >> (48 - bits));
 }

--- a/prngs/PRNG.h
+++ b/prngs/PRNG.h
@@ -50,7 +50,7 @@ public:
     virtual void setBounds(uint32_t, uint32_t) = 0;
     virtual int64_t getMinSeed() = 0;
     virtual int64_t getMaxSeed() = 0;
-
+    PRNG():m_isBounded(false) {};
     virtual ~PRNG(){};
 
 protected:
@@ -60,5 +60,4 @@ protected:
     uint32_t m_maxBound;
     bool m_isBounded;
 };
-
 #endif /* PRNG_H_ */


### PR DESCRIPTION
Not sure is it the right way as I don't have libcppunit-dev for testing and writing test case but these changes are necessary to generate the same samples when using the same seed. (negative numbers have the same hexdecimal values)

----- Java 1.8 output when using seed 1454529774324 ----
-288307751
2073090696
-433705358
-1513924933
## -1502370334

--- Output after my changes  ---
nothize@fuji /cygdrive/r/untwister
$ ./untwister.exe -r java -g 1454529774324 -D 5
4006659545
2073090696
3861261938
2781042363
## 2792596962

------- Output of commit id 8e0c077478fffc4acd7745dc213408b3dd54c8ac -------
nothize@fuji /cygdrive/r/untwister
$ ./untwister.exe -r java -g 1454529774324 -D 5
1875090688
3733243077
2826257263
2869094006
## 3809370776
